### PR TITLE
removed reconcile and clear functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,24 @@ split_budget = YnabSplitBudget(user=user, partner=partner)
 ### 3. Split transactions
 Call the `split()` method of the instance. It will split flagged transactions in the budget into a subtransaction with
 the original category and a transfer to the split account. By default, the transfer transactions will show up as 
-uncleared in the split account. The optional `clear` parameter allows to automatically clear the transactions in 
-the split account. The function returns the updated transactions after applying the split.
+uncleared in the split account.
 ```py
 split_budget.split()
 ```
 
 ### 4. Push new splits to partner split account
 Calling the `push()` function will insert new transactions from user split account into split account of partner to keep
-both accounts in sync. By default, the function will compare and insert transactions of the last 30 days. Optionally it 
+both accounts in sync. By default, the function will only consider cleared transactions. This is in general a safer 
+option as it forces users to manually check and clear transactions in the split account. However, it makes running the 
+whole functionality automatically cumbersome, hence the function takes an optional `include_uncleared` parameter which, 
+if set to `True`, makes it also consider uncleared transactions. 
+Additionally by default, the function will compare and insert transactions of the last 30 days. Optionally it 
 takes a `since` parameter in the form of `datetime.date` to set a timeframe different from 30 days. 
 
 ```py
 split_budget.push()
+# or optionally with considering uncleared transactions as well
+split_budget.push(include_uncleared=True)
 ```
 ## Advanced Usage
 ### Check Balances
@@ -76,12 +81,6 @@ By default, the function compares transactions of the last 30 days. Optionally i
 form of `datetime.date` to set a timeframe different from 30 days.
 ```py
 split_budget.delete_orphans()
-```
-### Reconcile split account
-The `reconcile()` function allows to reconcile the split account. It does check if the balances match before reconciling
-and will an `BalancesDontMatch` error if they don't.
-```py 
-split_budget.reconcile()
 ```
 
 ### Show Logs

--- a/tests/test_syncrepository.py
+++ b/tests/test_syncrepository.py
@@ -15,7 +15,7 @@ def test_fetch_new_to_insert_new(mock_lookup, mock_changed):
 	mock_changed.return_value = [mock_transaction]
 	mock_lookup.return_value = [mock_lookup_transaction]
 	# Act
-	strepo = SyncRepository(user=MagicMock(), partner=MagicMock())
+	strepo = SyncRepository(user=MagicMock(), partner=MagicMock(), include_uncleared=True)
 	t = strepo.fetch_roots_wo_complement(since=date(2024, 1, 1))
 	# Assert
 	assert isinstance(t[0], RootTransaction)
@@ -31,7 +31,7 @@ def test_fetch_new_to_insert_not_new(mock_lookup, mock_changed):
 	mock_changed.return_value = [mock_transaction]
 	mock_lookup.return_value = [mock_complement]
 	# Act
-	strepo = SyncRepository(user=MagicMock(), partner=MagicMock())
+	strepo = SyncRepository(user=MagicMock(), partner=MagicMock(), include_uncleared=True)
 	t = strepo.fetch_roots_wo_complement(since=date(2024, 1, 1))
 	# Assert
 	assert len(t) == 0
@@ -44,7 +44,7 @@ def test_fetch_new_to_insert_empty(mock_lookup, mock_changed):
 	mock_changed.return_value = []
 	mock_lookup.return_value = []
 	# Act
-	strepo = SyncRepository(user=MagicMock(), partner=MagicMock())
+	strepo = SyncRepository(user=MagicMock(), partner=MagicMock(), include_uncleared=True)
 	t = strepo.fetch_roots_wo_complement(since=date(2024, 1, 1))
 	# Assert
 	assert len(t) == 0

--- a/ynabsplitbudget/__main__.py
+++ b/ynabsplitbudget/__main__.py
@@ -20,9 +20,9 @@ if __name__ == '__main__':
 										   '[-p | --partner] <path/partner.yaml> '
 										   '[-s | --split] '
 										   '[-i | --push] '
+										   '[-iu | --push-uncleared] '
 										   '[-b | --balances]'
 										   '[-d | --delete-orphans]'
-										   '[-r | --reconcile]'
 										   '[--since "YYYY-mm-dd"]')
 	parser.add_argument("-u", "--user", type=str, required=True,
 						help="path of config YAML to use for user")
@@ -36,10 +36,10 @@ if __name__ == '__main__':
 						help="raise error if balances of the two accounts don't match")
 	parser.add_argument("-d", "--delete-orphans", action="store_true",
 						help="deletes orphaned transactions in partner account")
-	parser.add_argument("-r", "--reconcile", action="store_true",
-						help="reconciles account if balance matches with partner account")
 	parser.add_argument("--since", type=str,
 						help='provide optional date if library should use something else than 30 days default')
+	parser.add_argument('-iu', "--push-uncleared", type=str,
+						help='push split transactions to partner account including uncleared transactions')
 
 	args = parser.parse_args()
 
@@ -60,11 +60,11 @@ if __name__ == '__main__':
 		ysb.split()
 	if args.push:
 		ysb.push(since=since)
+	elif args.push_uncleared:
+		ysb.push(since=since, include_uncleared=True)
 	if args.delete_orphans:
 		ysb.delete_orphans(since=since)
-	if args.balances or args.reconcile:
+	if args.balances:
 		ysb.raise_on_balances_off()
-	if args.reconcile:
-		ysb.reconcile()
 
 

--- a/ynabsplitbudget/adjusters.py
+++ b/ynabsplitbudget/adjusters.py
@@ -13,7 +13,8 @@ class ReconcileAdjuster(Adjuster):
 
 	def adjust(self, original: Transaction, modifier: Modifier) -> Modifier:
 		modifier.cleared = 'reconciled'
-		modifier.category = self.categories.fetch_by_name('Inflow: Ready to Assign')
+		if not modifier.category:
+			modifier.category = self.categories.fetch_by_name('Inflow: Ready to Assign')
 		return modifier
 
 
@@ -30,7 +31,8 @@ class ClearAdjuster(Adjuster):
 
 	def adjust(self, original: Transaction, modifier: Modifier) -> Modifier:
 		modifier.cleared = 'cleared'
-		modifier.category = self.categories.fetch_by_name('Inflow: Ready to Assign')
+		if not modifier.category:
+			modifier.category = self.categories.fetch_by_name('Inflow: Ready to Assign')
 		return modifier
 
 
@@ -43,7 +45,7 @@ class SplitAdjuster(Adjuster):
 		self.account_id = account_id
 
 	def filter(self, transactions: List[Transaction]) -> List[Transaction]:
-		return [t for t in transactions if t.cleared == 'cleared' and t.flag_color == self.flag_color
+		return [t for t in transactions if t.cleared == 'cleared' and t.approved and t.flag_color == self.flag_color
 				and not t.subtransactions and not t.account.id == self.account_id]
 
 	def adjust(self, original: Transaction, modifier: Modifier) -> Modifier:


### PR DESCRIPTION
### Bugfixes
⚠️ YNAB API doesn't handle updating transfer transaction properties as expected, hence 
- removed `clear` parameter from `split()` function
- removed `reconcile()` function 

### New Functionality
- added `include_uncleared` option to `push()` function to allow skipping intermediate manual step of clearing transactions in split account 